### PR TITLE
Prevent deprecation warning in signal_interpolate

### DIFF
--- a/neurokit2/signal/signal_interpolate.py
+++ b/neurokit2/signal/signal_interpolate.py
@@ -100,7 +100,7 @@ def signal_interpolate(x_values, y_values=None, x_new=None, method="quadratic", 
         x_new = np.linspace(x_values[0], x_values[-1], x_new)
     else:
         # if x_values is identical to x_new, no need for interpolation
-        if np.all(x_values == x_new):
+        if np.array_equal(x_values, x_new):
             return y_values
 
     # If only one value, return a constant signal


### PR DESCRIPTION
# Description

This PR aims to prevent the following warning when running `signal_interpolate()`:
`DeprecationWarning: elementwise comparison failed; this will raise an error in the future.`


# Proposed Changes

I changed the `signal_interpolate()` function so that a line (that I think I added, by the way, sorry) using `np.all` now uses `np.array_equal` instead: 
https://stackoverflow.com/questions/44574679/python-deprecationwarning-elementwise-comparison-failed-this-will-raise-an


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).